### PR TITLE
Ensure models remains an observable array after add

### DIFF
--- a/src/Collection.js
+++ b/src/Collection.js
@@ -119,7 +119,7 @@ export default class Collection<T: Model> {
    */
   @action add (data: Array<{ [key: string]: any }>): Array<T> {
     const models = data.map(d => this.build(d))
-    this.models = this.models.concat(models)
+    this.models.push(...models)
     return models
   }
 


### PR DESCRIPTION
After adding new models to a collection, `this.models` is no longer observable as `Array.prototype.concat()` returns a new array. Changed the add method to use `Array.prototype.push()` to keep the original observable array referenced.