### PR TITLE
Use correct class name for ErrorObject

### DIFF
--- a/src/ErrorObject.js
+++ b/src/ErrorObject.js
@@ -1,7 +1,7 @@
 // @flow
 import type { Label } from './types'
 
-export default class Request {
+export default class ErrorObject {
   label: Label;
   body: {};
 


### PR DESCRIPTION
It appears the ErrorObject based on the Request object but hadn't been renamed.