### PR TITLE
Clear error after successful request

### DIFF
--- a/__tests__/Collection.spec.js
+++ b/__tests__/Collection.spec.js
@@ -123,6 +123,16 @@ describe('Collection', () => {
           }
         })
 
+        it('clears the error', async () => {
+          reject()
+          try {
+            await collection.fetch()
+          } catch (e) {}
+          resolve([])()
+          await collection.fetch()
+          expect(collection.error).toBe(null)
+        })
+
         it('removes the model', async () => {
           try {
             await collection.create(newItem)
@@ -162,6 +172,15 @@ describe('Collection', () => {
             expect(collection.error.label).toBe('creating')
             expect(collection.error.body).toBe(error)
           }
+        })
+        it('clears the error', async () => {
+          reject()
+          try {
+            await collection.fetch()
+          } catch (e) {}
+          resolve([])()
+          await collection.fetch()
+          expect(collection.error).toBe(null)
         })
       })
 
@@ -210,6 +229,15 @@ describe('Collection', () => {
         await collection.fetch()
         expect(collection.models.length).toBe(2)
         expect(collection.at(1).get('name')).toBe('bob')
+      })
+
+      it('clears the error', async () => {
+        try {
+          await collection.fetch()
+        } catch (e) {}
+        resolve([item, { id: 2, name: 'bob' }])()
+        await collection.fetch()
+        expect(collection.error).toBe(null)
       })
     })
   })
@@ -290,6 +318,15 @@ describe('Collection', () => {
             expect(collection.error.label).toBe('updating')
             expect(collection.error.body).toBe(error)
           }
+        })
+
+        it('clears the error', async () => {
+          try {
+            await collection.fetch()
+          } catch (e) {}
+          resolve([])()
+          await collection.fetch()
+          expect(collection.error).toBe(null)
         })
       })
 

--- a/__tests__/Collection.spec.js
+++ b/__tests__/Collection.spec.js
@@ -150,7 +150,7 @@ describe('Collection', () => {
         it('nullifies the request', async () => {
           await collection.create(newItem)
           expect(collection.models.length).toBe(2)
-          expect(collection.request).toBe(null)
+          expect(collection.at(1).request).toBe(null)
         })
 
         it('clears the error', async () => {

--- a/__tests__/Model.spec.js
+++ b/__tests__/Model.spec.js
@@ -1,7 +1,10 @@
 import { Collection, Model, apiClient, Request } from '../src'
 import MockApi from './mocks/api'
+import ErrorObject from '../src/ErrorObject'
 
 const error = 'boom!'
+const errorObject = new ErrorObject('fetch', error)
+
 apiClient(MockApi)
 
 class MyCollection extends Collection {
@@ -171,6 +174,7 @@ describe('Model', () => {
 
           describe('when it succeeds', () => {
             beforeEach(() => {
+              model.error = errorObject
               resolve({ id: 1, name: 'coltrane' })()
             })
 
@@ -184,6 +188,11 @@ describe('Model', () => {
               return model.save({ name }).then(() => {
                 expect(model.request).toBe(null)
               })
+            })
+
+            it('clears the error', async () => {
+              await model.save({ name })
+              expect(model.error).toBe(null)
             })
           })
         })
@@ -208,6 +217,7 @@ describe('Model', () => {
 
           describe('when it succeeds', () => {
             beforeEach(() => {
+              model.error = errorObject
               resolve({ id: 2, name: 'dylan' })()
             })
 
@@ -221,6 +231,11 @@ describe('Model', () => {
               return model.save({ name }).then(() => {
                 expect(model.request).toBe(null)
               })
+            })
+
+            it('clears the error', async () => {
+              await model.save({ name })
+              expect(model.error).toBe(null)
             })
           })
         })
@@ -273,6 +288,7 @@ describe('Model', () => {
 
       describe('when it succeeds', () => {
         beforeEach(() => {
+          model.error = errorObject
           resolve({ id: 1, name: 'coltrane' })()
         })
 
@@ -286,6 +302,11 @@ describe('Model', () => {
           return model.save({ name }).then(() => {
             expect(model.request).toBe(null)
           })
+        })
+
+        it('clears the error', async () => {
+          await model.save({ name })
+          expect(model.error).toBe(null)
         })
       })
     })
@@ -310,6 +331,7 @@ describe('Model', () => {
 
       describe('when it succeeds', () => {
         beforeEach(() => {
+          model.error = errorObject
           resolve({ id: 2, name: 'dylan' })()
         })
 
@@ -323,6 +345,11 @@ describe('Model', () => {
           return model.save({ name }).then(() => {
             expect(model.request).toBe(null)
           })
+        })
+
+        it('clears the error', async () => {
+          await model.save({ name })
+          expect(model.error).toBe(null)
         })
       })
     })
@@ -373,12 +400,20 @@ describe('Model', () => {
       })
 
       describe('when it succeeds', () => {
-        beforeEach(resolve())
+        beforeEach(() => {
+          model.error = errorObject
+          resolve()()
+        })
 
         it('nullifies the request', () => {
           return model.destroy().then(() => {
             expect(model.request).toBe(null)
           })
+        })
+
+        it('clears the error', async () => {
+          await model.save({ name })
+          expect(model.error).toBe(null)
         })
       })
     })
@@ -408,7 +443,10 @@ describe('Model', () => {
       })
 
       describe('when it succeeds', () => {
-        beforeEach(resolve())
+        beforeEach(() => {
+          model.error = errorObject
+          resolve()()
+        })
 
         it('applies changes', () => {
           return model.destroy({ optimistic: false }).then(() => {
@@ -420,6 +458,11 @@ describe('Model', () => {
           return model.destroy({ optimistic: false }).then(() => {
             expect(model.request).toBe(null)
           })
+        })
+
+        it('clears the error', async () => {
+          await model.destroy({ optimistic: false })
+          expect(model.error).toBe(null)
         })
       })
     })
@@ -444,7 +487,10 @@ describe('Model', () => {
     })
 
     describe('when it succeeds', () => {
-      beforeEach(resolve({ name: 'bill' }))
+      beforeEach(() => {
+        model.error = errorObject
+        resolve({ name: 'bill' })()
+      })
 
       it('returns the response', () => {
         return model.fetch().then((response) => {
@@ -462,6 +508,11 @@ describe('Model', () => {
         return model.fetch().then(() => {
           expect(model.request).toBe(null)
         })
+      })
+
+      it('clears the error', async () => {
+        await model.fetch()
+        expect(model.error).toBe(null)
       })
     })
   })
@@ -485,7 +536,10 @@ describe('Model', () => {
     })
 
     describe('when it succeeds', () => {
-      beforeEach(resolve('foo'))
+      beforeEach(() => {
+        model.error = errorObject
+        resolve('foo')()
+      })
 
       it('returns the response', () => {
         return model.rpc('approve').then((response) => {
@@ -497,6 +551,11 @@ describe('Model', () => {
         return model.rpc('approve').then(() => {
           expect(model.request).toBe(null)
         })
+      })
+
+      it('clears the error', async () => {
+        await model.rpc('approve')
+        expect(model.error).toBe(null)
       })
     })
   })

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -235,6 +235,7 @@ export default class Collection<T: Model> {
         this.add([data])
       }
       this.request = null
+      this.error = null
     })
 
     return data
@@ -269,6 +270,7 @@ export default class Collection<T: Model> {
     runInAction('fetch-done', () => {
       this.set(data, options)
       this.request = null
+      this.error = null
     })
 
     return data
@@ -302,6 +304,7 @@ export default class Collection<T: Model> {
     }
 
     this.request = null
+    this.error = null
 
     return response
   }

--- a/src/Model.js
+++ b/src/Model.js
@@ -174,6 +174,7 @@ export default class Model {
     runInAction('fetch-done', () => {
       this.set(data)
       this.request = null
+      this.error = null
     })
 
     return data
@@ -249,6 +250,7 @@ export default class Model {
 
     runInAction('save-done', () => {
       this.request = null
+      this.error = null
       this.set(response)
     })
 
@@ -298,6 +300,7 @@ export default class Model {
     runInAction('create-done', () => {
       this.set(data)
       this.request = null
+      this.error = null
     })
 
     return data
@@ -344,6 +347,7 @@ export default class Model {
         this.collection.remove([this.id])
       }
       this.request = null
+      this.error = null
     })
 
     return null
@@ -377,6 +381,7 @@ export default class Model {
     }
 
     this.request = null
+    this.error = null
 
     return response
   }


### PR DESCRIPTION
The collection.error object is hanging around even after a successful requests. Does it make sense to clear it or did I misunderstand something?