### PR TITLE
Fixes model creation attributes

### DIFF
--- a/__tests__/Model.spec.js
+++ b/__tests__/Model.spec.js
@@ -140,6 +140,22 @@ describe('Model', () => {
           model.save(item)
           expect(collection.create).toBeCalledWith(model, { optimistic: true })
         })
+
+        it('sends merged attributes on the request', () => {
+          const adapter = apiClient()
+          const spy = jest.spyOn(adapter, 'post')
+
+          model.save({ name })
+
+          expect(spy).toHaveBeenCalledTimes(1)
+          expect(spy.mock.calls[0][1]).toEqual({
+            name: 'dylan',
+            album: 'kind of blue'
+          })
+
+          spy.mockReset()
+          spy.mockRestore()
+        })
       })
 
       describe('and it does not have a collection', () => {

--- a/__tests__/Model.spec.js
+++ b/__tests__/Model.spec.js
@@ -147,6 +147,22 @@ describe('Model', () => {
           model.collection = null
         })
 
+        it('sends merged attributes on the request', () => {
+          const adapter = apiClient()
+          const spy = jest.spyOn(adapter, 'post')
+
+          model.save({ name })
+
+          expect(spy).toHaveBeenCalledTimes(1)
+          expect(spy.mock.calls[0][1]).toEqual({
+            name: 'dylan',
+            album: 'kind of blue'
+          })
+
+          spy.mockReset()
+          spy.mockRestore()
+        })
+
         describe('if its optimistic (default)', () => {
           it('it sets model straight away', () => {
             model.save({ name })

--- a/src/Model.js
+++ b/src/Model.js
@@ -203,7 +203,7 @@ export default class Model {
       if (this.collection) {
         return this.collection.create(this, { optimistic })
       } else {
-        return this._create(attributes, { optimistic })
+        return this._create(this.attributes.toJS(), { optimistic })
       }
     }
 


### PR DESCRIPTION
When calling `model.save(newAttributes)` on a new model, the request only receives `newAttributes` as params, ignoring the existing attributes on the model.

#### Example

1. New model that belongs to a collection:

```es6
const model = usersCollection.build({ name: 'User 1', email: 'user1@test.com' })

model.save({ name: 'User 2' })
// => [POST] { name: 'User 2', email: 'user1@test.com' }
```

2. New model that doesn't belong to any collection:

```es6
const model = new User({ name: 'User 1', email: 'user1@test.com' })

model.save({ name: 'User 2' })
// => [POST] { name: 'User 2' }
```