### PR TITLE
Save nested observable objects

### DIFF
--- a/__tests__/Model.spec.js
+++ b/__tests__/Model.spec.js
@@ -27,6 +27,7 @@ describe('Model', () => {
   let collection
   let model
   let item
+  let spy
 
   function resolve (attr) {
     return () => {
@@ -42,6 +43,14 @@ describe('Model', () => {
     item = { id: 1, name: 'miles', album: 'kind of blue' }
     collection = new MyCollection([item])
     model = collection.at(0)
+  })
+
+  afterEach(() => {
+    if (spy) {
+      spy.mockReset()
+      spy.mockRestore()
+      spy = null
+    }
   })
 
   describe('isRequest', () => {
@@ -143,8 +152,8 @@ describe('Model', () => {
 
         it('sends merged attributes on the request', () => {
           const adapter = apiClient()
-          const spy = jest.spyOn(adapter, 'post')
 
+          spy = jest.spyOn(adapter, 'post')
           model.save({ name })
 
           expect(spy).toHaveBeenCalledTimes(1)
@@ -152,9 +161,6 @@ describe('Model', () => {
             name: 'dylan',
             album: 'kind of blue'
           })
-
-          spy.mockReset()
-          spy.mockRestore()
         })
       })
 
@@ -165,8 +171,8 @@ describe('Model', () => {
 
         it('sends merged attributes on the request', () => {
           const adapter = apiClient()
-          const spy = jest.spyOn(adapter, 'post')
 
+          spy = jest.spyOn(adapter, 'post')
           model.save({ name })
 
           expect(spy).toHaveBeenCalledTimes(1)
@@ -174,9 +180,6 @@ describe('Model', () => {
             name: 'dylan',
             album: 'kind of blue'
           })
-
-          spy.mockReset()
-          spy.mockRestore()
         })
 
         describe('if its optimistic (default)', () => {

--- a/__tests__/Model.spec.js
+++ b/__tests__/Model.spec.js
@@ -302,6 +302,28 @@ describe('Model', () => {
           expect(model.get('album')).toBe(item.album)
           expect(model.request.label).toBe('updating')
         })
+
+        it('sends merged attributes on the request', () => {
+          const adapter = apiClient()
+
+          spy = jest.spyOn(adapter, 'put')
+          model.save({
+            name,
+            tracks: [
+              { name: 'Track 1' },
+              { name: 'Track 2' }
+            ]
+          })
+
+          expect(spy).toHaveBeenCalledTimes(1)
+          expect(spy.mock.calls[0][1]).toEqual({
+            name: 'dylan',
+            tracks: [
+              { name: 'Track 1' },
+              { name: 'Track 2' }
+            ]
+          })
+        })
       })
 
       describe('and its not patching', () => {
@@ -310,6 +332,29 @@ describe('Model', () => {
           expect(model.get('name')).toBe('dylan')
           expect(model.get('album')).toBe('kind of blue')
           expect(model.request.label).toBe('updating')
+        })
+
+        it('sends merged attributes on the request', () => {
+          const adapter = apiClient()
+
+          spy = jest.spyOn(adapter, 'put')
+          model.save({
+            name,
+            tracks: [
+              { name: 'Track 1' },
+              { name: 'Track 2' }
+            ]
+          }, { patch: false })
+
+          expect(spy).toHaveBeenCalledTimes(1)
+          expect(spy.mock.calls[0][1]).toEqual({
+            ...item,
+            name: 'dylan',
+            tracks: [
+              { name: 'Track 1' },
+              { name: 'Track 2' }
+            ]
+          })
         })
       })
 

--- a/__tests__/Model.spec.js
+++ b/__tests__/Model.spec.js
@@ -40,7 +40,18 @@ describe('Model', () => {
   }
 
   beforeEach(() => {
-    item = { id: 1, name: 'miles', album: 'kind of blue' }
+    item = {
+      id: 1,
+      name: 'miles',
+      album: 'kind of blue',
+      tracks: [
+        { name: 'So What' },
+        { name: 'Freddie Freeloader' },
+        { name: 'Blue in Green' },
+        { name: 'All Blues' },
+        { name: 'Flamenco Sketches' }
+      ]
+    }
     collection = new MyCollection([item])
     model = collection.at(0)
   })
@@ -152,14 +163,17 @@ describe('Model', () => {
 
         it('sends merged attributes on the request', () => {
           const adapter = apiClient()
+          const attributes = { ...item }
+
+          delete attributes.id
 
           spy = jest.spyOn(adapter, 'post')
           model.save({ name })
 
           expect(spy).toHaveBeenCalledTimes(1)
           expect(spy.mock.calls[0][1]).toEqual({
-            name: 'dylan',
-            album: 'kind of blue'
+            ...attributes,
+            name: 'dylan'
           })
         })
       })
@@ -171,14 +185,17 @@ describe('Model', () => {
 
         it('sends merged attributes on the request', () => {
           const adapter = apiClient()
+          const attributes = { ...item }
+
+          delete attributes.id
 
           spy = jest.spyOn(adapter, 'post')
           model.save({ name })
 
           expect(spy).toHaveBeenCalledTimes(1)
           expect(spy.mock.calls[0][1]).toEqual({
-            name: 'dylan',
-            album: 'kind of blue'
+            ...attributes,
+            name: 'dylan'
           })
         })
 

--- a/__tests__/Model.spec.js
+++ b/__tests__/Model.spec.js
@@ -482,7 +482,7 @@ describe('Model', () => {
         it('rolls back the changes', () => {
           return model.destroy().catch(() => {
             expect(collection.models.length).toBe(1)
-            expect(collection.at(0).get('name')).toBe(item.name)
+            expect(collection.at(0).toJS()).toEqual(item)
           })
         })
 

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -210,7 +210,7 @@ export default class Collection<T: Model> {
   ): Promise<*> {
     let model
     let attributes = attributesOrModel instanceof Model
-      ? attributesOrModel.attributes.toJS()
+      ? attributesOrModel.toJS()
       : attributesOrModel
     const label: Label = 'creating'
 

--- a/src/Model.js
+++ b/src/Model.js
@@ -203,7 +203,7 @@ export default class Model {
       if (this.collection) {
         return this.collection.create(this, { optimistic })
       } else {
-        return this._create(this.attributes.toJS(), { optimistic })
+        return this._create(this.toJS(), { optimistic })
       }
     }
 

--- a/src/Model.js
+++ b/src/Model.js
@@ -210,7 +210,7 @@ export default class Model {
     let newAttributes
     let data
     const label: Label = 'updating'
-    const originalAttributes = this.attributes.toJS()
+    const originalAttributes = this.toJS()
 
     if (patch) {
       newAttributes = Object.assign({}, originalAttributes, attributes)


### PR DESCRIPTION
There is a bug when trying to save nested observable objects. Example:

```
model.save({
  products: [
    { name: 'Product 1' }
  ]
})
```

#### Result:
```
[POST] { products: {} } // products is an ObservableArray so it's serialized to {}
```

#### Expected:
```
[POST] { products: [{ name: 'Product 1' }] }
```

#### Reference
https://mobx.js.org/refguide/map.html

> toJS(). Returns a shallow plain object representation of this map. (For a deep copy use mobx.toJS(map)).