### PR TITLE
Add data argument in destroy calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## `2.3.0`
+
+:tophat:
+
+  - Added extra `data` parameter for `destroy` calls. (kudos to @fcsonline)
+
 ## `2.2.1`
 
 :tophat:

--- a/README.md
+++ b/README.md
@@ -225,9 +225,11 @@ await promise
 company.get('name') // => 'Redbooth'
 ```
 
-#### `destroy(options: Object): Promise`
+#### `destroy(attributes: Object, options: Object): Promise`
 
-Tells the API to destroy this resource.
+Tells the API to destroy this resource. It accepts some attributes
+as the first argument so you can use send extra information during
+the destroy process.
 
 Options:
 

--- a/__tests__/Model.spec.js
+++ b/__tests__/Model.spec.js
@@ -510,6 +510,24 @@ describe('Model', () => {
           expect(model.error).toBe(null)
         })
       })
+
+      describe('when it succeeds with the new destroy signature', () => {
+        beforeEach(() => {
+          model.error = errorObject
+          resolve()()
+        })
+
+        it('nullifies the request', () => {
+          return model.destroy({ message: 'foo' }, { optimistic: true }).then(() => {
+            expect(model.request).toBe(null)
+          })
+        })
+
+        it('clears the error', async () => {
+          await model.save({ name })
+          expect(model.error).toBe(null)
+        })
+      })
     })
 
     describe('if its pessimistic', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-rest",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "REST conventions for mobx.",
   "repository": {
     "type": "git",

--- a/src/Model.js
+++ b/src/Model.js
@@ -310,14 +310,17 @@ export default class Model {
    * too
    */
   @action
-  async destroy ({ optimistic = true }: DestroyOptions = {}): Promise<*> {
+  async destroy (
+    attributes: {},
+    { optimistic = true }: DestroyOptions = {}
+  ): Promise<*> {
     if (!this.has(this.primaryKey) && this.collection) {
       this.collection.remove([this.optimisticId])
       return Promise.resolve()
     }
 
     const label: Label = 'destroying'
-    const { promise, abort } = apiClient().del(this.url())
+    const { abort, promise } = apiClient().del(this.url(), attributes)
 
     if (optimistic && this.collection) {
       this.collection.remove([this.id])

--- a/src/types.js
+++ b/src/types.js
@@ -35,5 +35,5 @@ export type Adapter = {
   get(path: string, data?: {}, options?: {}): Response,
   post(path: string, data?: {}, options?: {}): Response,
   put(path: string, data?: {}, options?: {}): Response,
-  del(path: string, options?: {}): Response
+  del(path: string, data?: {}, options?: {}): Response
 }


### PR DESCRIPTION
I'm adding a new `data` argument to destroy calls to let users send more information during a `DELETE` request.