### PR TITLE
use lodash babel plugin to optimize bundle size

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,6 +7,7 @@
     "transform-flow-strip-types",
     "transform-decorators-legacy",
     "transform-async-to-generator",
-    "transform-runtime"
+    "transform-runtime",
+    "lodash"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel-core": "^6.25.0",
     "babel-eslint": "^7.2.3",
     "babel-jest": "^20.0.3",
+    "babel-plugin-lodash": "^3.3.2",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",


### PR DESCRIPTION
Fixes #30 
This results in reducing the lodash-specific bundle contribution from ~500KB to ~118KB (un-minified)

the lodash methods are still contributing a significant amount of overhead, but at least with this babel plugin the codebase can remain as is and we can realize some savings

This simply requires merging and re-publishing the package and consumers can enjoy a slightly smaller bundle size.

NOTE: I had to push this to my fork via `--no-verify` because I had weird `flow` specific lint errors (in code I didn't touch at all), which I assume you have handled on your end.

