### PR TITLE
Remove abort

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,7 +562,6 @@ Your collections and models will have the following state shape:
 models: Array<Model>      // This is where the models live
 request: {                // An ongoing request
   label: string,          // Examples: 'updating', 'creating', 'fetching', 'destroying' ...
-  abort: () => void,      // A method to abort the ongoing request
   progress: number        // If uploading a file, represents the progress
 },
 error: {                  // A failed request
@@ -577,8 +576,7 @@ error: {                  // A failed request
 attributes: Object    // The resource attributes
 optimisticId: string, // Client side id. Used for optimistic updates
 request: {            // An ongoing request
-  label: string,      // Examples: 'updating', 'creating', 'fetching', 'destroying' ...
-  abort: () => void,  // A method to abort the ongoing request
+  label: string      // Examples: 'updating', 'creating', 'fetching', 'destroying' ...
 },
 error: {              // A failed request
   label: string,      // Examples: 'updating', 'creating', 'fetching', 'destroying' ...

--- a/__tests__/Base.spec.js
+++ b/__tests__/Base.spec.js
@@ -19,7 +19,7 @@ describe(Base, () => {
     })
   })
 
-  describe('withRequest(labels, promise, abort)', () => {
+  describe('withRequest(labels, promise)', () => {
     it('returns a Request promise', () => {
       const request = model.withRequest('fetching', Promise.resolve())
 
@@ -27,8 +27,7 @@ describe(Base, () => {
     })
 
     it('tracks the request while is pending', () => {
-      const abort = () => {}
-      const request = model.withRequest('fetching', new Promise(() => {}), abort)
+      const request = model.withRequest('fetching', new Promise(() => {}))
 
       expect(model.requests.length).toBe(1)
       expect(model.requests[0]).toBe(request)

--- a/__tests__/mocks/api.js
+++ b/__tests__/mocks/api.js
@@ -20,7 +20,6 @@ export default {
     })
 
     return {
-      abort: () => {},
       promise
     }
   },

--- a/src/Base.js
+++ b/src/Base.js
@@ -16,7 +16,7 @@ export default class Base {
     throw new Error('You must implement this method')
   }
 
-  withRequest (labels: string | Array<string>, promise: Promise<*>, abort: ?() => void): Request {
+  withRequest (labels: string | Array<string>, promise: Promise<*>): Request {
     if (typeof labels === 'string') {
       labels = [labels]
     }
@@ -31,10 +31,7 @@ export default class Base {
         throw new ErrorObject(error)
       })
 
-    const request = new Request(handledPromise, {
-      labels,
-      abort
-    })
+    const request = new Request(handledPromise, { labels })
 
     this.requests.push(request)
 
@@ -64,8 +61,8 @@ export default class Base {
    */
   @action
   rpc (label: string, endpoint: string, options?: {}): Request {
-    const { promise, abort } = apiClient().post(`${this.url()}/${endpoint}`, options)
+    const { promise } = apiClient().post(`${this.url()}/${endpoint}`, options)
 
-    return this.withRequest(label, promise, abort)
+    return this.withRequest(label, promise)
   }
 }

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -244,7 +244,7 @@ export default class Collection extends Base {
     { optimistic = true }: CreateOptions = {}
   ): Request {
     const model = this.build(attributesOrModel)
-    const { abort, promise } = model.save()
+    const { promise } = model.save()
 
     if (optimistic) {
       this.add(model)
@@ -264,7 +264,7 @@ export default class Collection extends Base {
         throw error
       })
 
-    return this.withRequest('creating', promise, abort)
+    return this.withRequest('creating', promise)
   }
 
   /**
@@ -276,7 +276,7 @@ export default class Collection extends Base {
    */
   @action
   fetch (options: SetOptions = {}): Request {
-    const { abort, promise } = apiClient().get(this.url(), options)
+    const { promise } = apiClient().get(this.url(), options)
 
     promise
       .then(data => {
@@ -284,6 +284,6 @@ export default class Collection extends Base {
         return data
       })
 
-    return this.withRequest('fetching', promise, abort)
+    return this.withRequest('fetching', promise)
   }
 }

--- a/src/Model.js
+++ b/src/Model.js
@@ -204,7 +204,7 @@ export default class Model extends Base {
    */
   @action
   fetch ({ data, ...otherOptions }: { data?: {} } = {}): Request {
-    const { abort, promise } = apiClient().get(this.url(), data, otherOptions)
+    const { promise } = apiClient().get(this.url(), data, otherOptions)
 
     promise
       .then(data => {
@@ -213,7 +213,7 @@ export default class Model extends Base {
         return data
       })
 
-    return this.withRequest('fetching', promise, abort)
+    return this.withRequest('fetching', promise)
   }
 
   /**
@@ -270,7 +270,7 @@ export default class Model extends Base {
       )
     }
 
-    const { promise, abort } = apiClient()[method](this.url(), data, otherOptions)
+    const { promise } = apiClient()[method](this.url(), data, otherOptions)
 
     promise
       .then(data => {
@@ -292,7 +292,7 @@ export default class Model extends Base {
         throw error
       })
 
-    return this.withRequest(['saving', label], promise, abort)
+    return this.withRequest(['saving', label], promise)
   }
 
   /**
@@ -313,7 +313,7 @@ export default class Model extends Base {
       return new Request(Promise.resolve())
     }
 
-    const { promise, abort } = apiClient().del(this.url(), otherOptions)
+    const { promise } = apiClient().del(this.url(), otherOptions)
 
     if (optimistic && collection) {
       collection.remove(this)
@@ -333,7 +333,7 @@ export default class Model extends Base {
         throw error
       })
 
-    return this.withRequest('destroying', promise, abort)
+    return this.withRequest('destroying', promise)
   }
 }
 

--- a/src/Request.js
+++ b/src/Request.js
@@ -4,15 +4,13 @@ import type { RequestOptions, RequestState } from './types'
 
 export default class Request {
   labels: Array<string>
-  abort: ?() => void
   promise: Promise<*>
   @observable progress: ?number
   @observable state: RequestState
 
-  constructor (promise: Promise<*>, { labels, abort, progress = 0 }: RequestOptions = {}) {
+  constructor (promise: Promise<*>, { labels, progress = 0 }: RequestOptions = {}) {
     this.state = 'pending'
     this.labels = labels
-    this.abort = abort
     this.progress = progress
     this.promise = promise
 

--- a/src/types.js
+++ b/src/types.js
@@ -20,12 +20,10 @@ export type SaveOptions = {
 }
 
 export type Response = {
-  abort: () => void,
   promise: Promise<*>
 }
 
 export type RequestOptions = {
-  abort: ?() => void,
   progress?: number,
   labels: Array<string>
 }


### PR DESCRIPTION
# WAT

In preparation for using the fetch adapter, we are deprecating support for `abort`.