### PR TITLE
Add data to destroy() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ What's changed 💅:
 Breaking changes ☢️:
   - Migrated to Mobx 5+
   - Rollback default `keepChanges` flag value to `false`.
+  - Compatible adapters need to implement `data` as their second argument [as such](https://github.com/masylum/mobx-rest-jquery-adapter/commit/1e55c15dc37d372db1ae4345dedef855b8fb7611#diff-1fdf421c05c1140f6d71444ea2b27638R135).
 
 ## `3.0.0.alpha`
 

--- a/__tests__/Model.spec.ts
+++ b/__tests__/Model.spec.ts
@@ -1013,7 +1013,7 @@ describe(Model, () => {
         it('they must be passed to the adapter', () => {
           model.destroy({ method: 'OPTIONS' })
 
-          expect(spy.mock.calls[0][1]).toEqual({
+          expect(spy.mock.calls[0][2]).toEqual({
             method: 'OPTIONS'
           })
         })

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -293,7 +293,7 @@ export default class Model extends Base {
    * too
    */
   @action
-  destroy ({ optimistic = true, ...otherOptions }: DestroyOptions = {}): Request {
+  destroy ({ data, optimistic = true, ...otherOptions }: DestroyOptions = {}): Request {
     const collection = this.collection
 
     if (this.isNew && collection) {
@@ -305,7 +305,7 @@ export default class Model extends Base {
       return new Request(Promise.resolve())
     }
 
-    const { promise, abort } = apiClient().del(this.url(), otherOptions)
+    const { promise, abort } = apiClient().del(this.url(), data, otherOptions)
 
     if (optimistic && collection) {
       collection.remove(this)

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,53 +1,54 @@
-export type OptimisticId = string;
-export type Id = number | OptimisticId;
-export type RequestState = 'pending' | 'fulfilled' | 'rejected';
+export type OptimisticId = string
+export type Id = number | OptimisticId
+export type RequestState = 'pending' | 'fulfilled' | 'rejected'
 
 export interface CreateOptions {
-  optimistic?: boolean;
+  optimistic?: boolean
   onProgress?: () => any
 }
 
 export interface DestroyOptions {
+  data?: {}
   optimistic?: boolean
 }
 
 export interface SaveOptions {
-  optimistic?: boolean;
-  patch?: boolean;
-  onProgress?: () => any;
-  keepChanges?: boolean;
+  optimistic?: boolean
+  patch?: boolean
+  onProgress?: () => any
+  keepChanges?: boolean
 }
 
 export interface Response {
-  abort: () => void;
-  promise: Promise<any>;
+  abort: () => void
+  promise: Promise<any>
 }
 
 export interface RequestOptions {
-  abort?: () => void | null;
-  progress?: number;
-  labels?: Array<string>;
+  abort?: () => void | null
+  progress?: number
+  labels?: Array<string>
 }
 
 export interface SetOptions {
-  add?: boolean;
-  change?: boolean;
-  remove?: boolean;
-  data?: {};
+  add?: boolean
+  change?: boolean
+  remove?: boolean
+  data?: {}
 }
 
 export interface GetOptions {
-  required?: boolean;
+  required?: boolean
 }
 
 export interface FindOptions {
-  required?: boolean;
+  required?: boolean
 }
 
 export interface Adapter {
-  get(path: string, data?: {}, options?: {}): Response;
-  patch(path: string, data?: {}, options?: {}): Response;
-  post(path: string, data?: {}, options?: {}): Response;
-  put(path: string, data?: {}, options?: {}): Response;
-  del(path: string, options?: {}): Response;
+  get(path: string, data?: {}, options?: {}): Response
+  patch(path: string, data?: {}, options?: {}): Response
+  post(path: string, data?: {}, options?: {}): Response
+  put(path: string, data?: {}, options?: {}): Response
+  del(path: string, data?: {}, options?: {}): Response
 }


### PR DESCRIPTION
# WAT
Adapters were not implementing the option to pass a body to DELETE requests. This changed in `mobx-rest-jquery-adapter` with [this commit](https://github.com/masylum/mobx-rest-jquery-adapter/commit/1e55c15dc37d372db1ae4345dedef855b8fb7611). 

Mobx-rest@3.0.0 will require this interface to its adapters.