### PR TITLE
Fix bug: collection's remove() did not remove items with string ids

### DIFF
--- a/__tests__/Collection.spec.ts
+++ b/__tests__/Collection.spec.ts
@@ -306,6 +306,7 @@ describe(Collection, () => {
         { id: 1 },
         { id: 2 }
       ])
+
       collection.remove(1)
 
       expect(collection.length).toBe(1)
@@ -374,6 +375,7 @@ describe(Collection, () => {
       describe('if add = true', () => {
         it('adds the new models', () => {
           collection.reset([{ id: 1 }])
+
           collection.set(
             [{ id: 2 }, { id: 3 }],
             { add: true, change: false, remove: false }
@@ -407,6 +409,7 @@ describe(Collection, () => {
             { id: 1, phone: '1234' },
             { id: 2, phone: '5678' }
           ])
+
           collection.set(
             [{ id: 1, phone: '8888' }, { id: 2, phone: '9999' }],
             { add: false, change: true, remove: false }
@@ -441,7 +444,7 @@ describe(Collection, () => {
     describe('if data has missing models', () => {
       describe('if remove = true', () => {
         it('removes the missing models', () => {
-          collection.reset([{ id: 1 }, { id: 2 }])
+          collection.reset([{ id: '1' }, { id: 2 }])
           collection.set(
             [{ id: 2 }],
             { add: false, change: false, remove: true }

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -188,11 +188,13 @@ export default abstract class Collection<T extends Model> extends Base {
 
       if (id instanceof Model && id.collection === this) {
         model = id
-      } else if (typeof id === 'number') {
+      } else if (typeof id === 'number' || typeof id === 'string') {
         model = this.get(id)
       }
 
-      if (!model) return
+      if (!model) {
+        return console.warn(`${this.constructor.name}: Model with id ${id} not found.`)
+      }
 
       this.models.splice(this.models.indexOf(model), 1)
       model.collection = undefined


### PR DESCRIPTION
# WAT
From [this PR](https://github.com/masylum/mobx-rest/pull/39) `Collection` stopped removing items that had string ids such as `optimisticId`.

This PR fixes this issue.