### PR TITLE
Add request attribute to Collections as well

### DIFF
--- a/src/Base.ts
+++ b/src/Base.ts
@@ -28,7 +28,9 @@ export default class Base {
 
     const handledPromise = promise
       .then(response => {
+        if (this.request === request) this.request = null
         this.requests.remove(request)
+
         return response
       })
       .catch(error => {
@@ -41,6 +43,7 @@ export default class Base {
       abort
     })
 
+    this.request = request
     this.requests.push(request)
 
     return request

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -282,9 +282,9 @@ export default class Model extends Base {
         throw error
       })
 
-    this.request = this.withRequest(['saving', label], promise, abort)
+    const request = this.withRequest(['saving', label], promise, abort)
 
-    return this.request
+    return request
   }
 
   /**


### PR DESCRIPTION
# WAT
In mobx-rest@3.0.0 we recovered the request attribute only for Models. Moved this logic to Base so that Collections also track their latest request.