### PR TITLE
xhr requests should only throw once

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-rest",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "REST conventions for mobx.",
   "jest": {
     "roots": [

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -265,8 +265,6 @@ export default abstract class Collection<T extends Model> extends Base {
       })
       .catch(error => {
         if (optimistic) this.remove(model)
-
-        throw error
       })
 
     return this.withRequest('creating', promise, abort)

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -278,8 +278,6 @@ export default class Model extends Base {
       })
       .catch(error => {
         this.set(currentAttributes)
-
-        throw error
       })
 
     const request = this.withRequest(['saving', label], promise, abort)
@@ -317,8 +315,6 @@ export default class Model extends Base {
       })
       .catch(error => {
         if (optimistic && collection) collection.add(this)
-
-        throw error
       })
 
     return this.withRequest('destroying', promise, abort)


### PR DESCRIPTION
# WAT
From the [mobx-rest@3.0.0.alpha](https://github.com/masylum/mobx-rest/pull/39) PR, xhr requests were throwing twice: one if the request failed and another one in some promise `catch` declarations. This results in `mobx-rest`'s REST methods throwing regardless of whether they were being caught.

In other words:

```javascript
function instanciatePromise () {
  const promise = new Promise((resolve, reject) => reject('error!'))

  promise.catch(e => {
      ....
      throw e
  })

  return promise
}

async function main () {
  try {
    await instanciatePromise()
  } catch (e) {
    ...
  }
}

main()
```

☝️ this throws an error despite the `try catch` statement.