### PR TITLE
Feature/throw better errors

### DIFF
--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -281,7 +281,9 @@ export default abstract class Collection<T extends Model> extends Base {
   fetch ({ data, ...otherOptions }: SetOptions = {}): Request {
     const { abort, promise } = apiClient().get(this.url(), data, otherOptions)
 
-    promise.then(data => this.set(data, otherOptions))
+    promise
+      .then(data => this.set(data, otherOptions))
+      .catch(_error => {}) // do nothing
 
     return this.withRequest('fetching', promise, abort)
   }

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -105,7 +105,7 @@ export default abstract class Collection<T extends Model> extends Base {
     const model = this.models.find(item => item.id === id)
 
     if (!model && required) {
-      throw Error(`Invariant: Model must be found with id: ${id}`)
+      throw new Error(`Invariant: Model must be found with id: ${id}`)
     }
 
     return model
@@ -140,7 +140,7 @@ export default abstract class Collection<T extends Model> extends Base {
     })
 
     if (!model && required) {
-      throw Error(`Invariant: Model must be found`)
+      throw new Error(`Invariant: Model must be found`)
     }
 
     return model

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -201,6 +201,7 @@ export default class Model extends Base {
         this.set(data)
         this.commitChanges()
       })
+      .catch(_error => {}) // do nothing
 
     return this.withRequest('fetching', promise, abort)
   }


### PR DESCRIPTION
# WAT
Two things
- Added a couple of missing `new` keywords in some `Error` instantiations.
- Added a couple of dummy `catch` statements missing in some internal promise handlers.

Regarding the second point, more ES6 promise learnings:
```javascript
function instantiatePromise () {
  const promise = new Promise((resolve, reject) => reject('error!'))

  promise
    .then(() => console.log('do something'))
  
  promise
    .then(() => console.log('do something'))
    .catch(e => ...)

  return promise
}

async function main () {
  try {
    await instantiatePromise()
  } catch (e) {
    ...
  }
}

main()
```

This ☝️ still throws an `UnhandledRejectionError` because there is a `then` handler that is missing a `catch` statement. All handlers must have a `catch` statement independently of other handlers having them, otherwise `UnhandledRejectionError` is raised.

```javascript
function instantiatePromise () {
  const promise = new Promise((resolve, reject) => reject('error!'))

  promise
    .then(() => console.log('do something'))
    .catch(e => ...)
  promise
    .then(() => console.log('do something'))
    .catch(e => ...)

  return promise
}

async function main () {
  try {
    await instantiatePromise()
  } catch (e) {
    ...
  }
}

main()
```

This does not throw ☝️ .