### PR TITLE
Do not create 2 Request objects when creating a model in collection

### DIFF
--- a/__tests__/Collection.spec.ts
+++ b/__tests__/Collection.spec.ts
@@ -527,6 +527,17 @@ describe(Collection, () => {
       expect(collection.at(0).toJS()).toEqual({ id: 1, phone: '1234' })
     })
 
+    it('only creates an instance of Request', async () => {
+      const attributes = { phone: '1234' }
+      const { promise } = collection.create(attributes)
+
+      expect(collection.requests.length).toEqual(1)
+      MockApi.resolvePromise({ id: 1, phone: '1234' })
+      await promise
+
+      expect(collection.requests.length).toEqual(0)
+    })
+
     describe('if optimistic', () => {
       it('immediately adds the new model to the collection', () => {
         const attributes = { phone: '1234' }

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -287,9 +287,7 @@ export default class Model extends Base {
         this.set(currentAttributes)
       })
 
-    const request = this.withRequest(['saving', label], promise, abort)
-
-    return request
+    return this.withRequest(['saving', label], promise, abort)
   }
 
   /**

--- a/src/Request.ts
+++ b/src/Request.ts
@@ -15,7 +15,7 @@ export default class Request {
     this.progress = progress = 0
     this.promise = promise
 
-    promise
+    this.promise
       .then(() => { this.state = 'fulfilled' })
       .catch(() => { this.state = 'rejected' })
   }


### PR DESCRIPTION
## What?
When creating a new model with collections' `create` method mobx-rest is wrapping existing `model.request` with a new `Request` object. 
This is wrong because is wrapping existing errors with a new `ErrorObject`. 

To avoid this we just reuse `mode.save` request object when creating a new model on `collection.create`