### PR TITLE
chore: use model name on mustFind exceptions

### DIFF
--- a/__tests__/Collection.spec.ts
+++ b/__tests__/Collection.spec.ts
@@ -5,15 +5,18 @@ import apiClient from '../src/apiClient'
 
 apiClient(MockApi)
 
-class MockCollection extends Collection<Model> {
+class MockModel extends Model {
+}
+
+class MockCollection extends Collection<MockModel> {
   indexes = ['phone']
 
   url (): string {
     return '/users'
   }
 
-  model (): typeof Model {
-    return Model
+  model (): typeof MockModel {
+    return MockModel
   }
 }
 
@@ -103,7 +106,7 @@ describe(Collection, () => {
 
   describe('model()', () => {
     it('returns the default model class', () => {
-      expect(collection.model()).toBe(Model)
+      expect(collection.model()).toBe(MockModel)
     })
   })
 
@@ -133,7 +136,7 @@ describe(Collection, () => {
       describe('if required', () => {
         it('throws', () => {
           expect(() => collection.get(999, { required: true }))
-            .toThrow('Invariant: Model must be found with id: 999')
+            .toThrow('Invariant: MockModel must be found with id: 999')
         })
       })
 
@@ -153,7 +156,7 @@ describe(Collection, () => {
     describe('if the model is not found', () => {
       it('throws', () => {
         expect(() => collection.mustGet(999))
-          .toThrow('Invariant: Model must be found with id: 999')
+          .toThrow('Invariant: MockModel must be found with id: 999')
       })
     })
   })
@@ -231,7 +234,7 @@ describe(Collection, () => {
       describe('if required', () => {
         it('throws', () => {
           expect(() => collection.find({ phone: '9999' }, { required: true }))
-            .toThrow('Invariant: Model must be found')
+            .toThrow('Invariant: MockModel must be found')
         })
       })
 
@@ -273,7 +276,7 @@ describe(Collection, () => {
     describe('if the model is not found', () => {
       it('throws', () => {
         expect(() => collection.mustFind({ phone: '9999' }))
-          .toThrow(Error(`Invariant: Model must be found`))
+          .toThrow(Error(`Invariant: MockModel must be found`))
       })
     })
   })

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -159,7 +159,7 @@ export default abstract class Collection<T extends Model> extends Base {
     const model = models && models[0]
 
     if (!model && required) {
-      throw new Error(`Invariant: Model must be found with ${this.primaryKey}: ${id}`)
+      throw new Error(`Invariant: ${this.model().name} must be found with ${this.primaryKey}: ${id}`)
     }
 
     return model
@@ -213,7 +213,7 @@ export default abstract class Collection<T extends Model> extends Base {
       : this.filter(query)[0]
 
     if (!model && required) {
-      throw new Error(`Invariant: Model must be found`)
+      throw new Error(`Invariant: ${this.model().name} must be found`)
     }
 
     return model
@@ -269,7 +269,7 @@ export default abstract class Collection<T extends Model> extends Base {
       }
 
       if (!model) {
-        return console.warn(`${this.constructor.name}: Model with ${this.primaryKey} ${id} not found.`)
+        return console.warn(`${this.constructor.name}: ${this.model().name} with ${this.primaryKey} ${id} not found.`)
       }
 
       this.models.splice(this.models.indexOf(model), 1)


### PR DESCRIPTION
They were always showing a message like:

> Invariant: Model must be found

Which made it hard to discriminate errors and group them on error
tracking tools.

This changes the message to something like:

> Invariant: User must be found