### PR TITLE
Add customizable endpoint for verbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ Options:
   - `patch = true` Whether we want to use the `PATCH` verb and semantics, sending
   only the changed attributes instead of the whole resource down the wire.
   - `keepChanges = false` Whether we want to keep the changes after the response from the API.
+  - `path` (Optional) Target API path where we want perform the save action. It
+      has preference over `url()`.
 
 Example:
 
@@ -295,6 +297,8 @@ Options:
 
   - `optimistic = true` Whether we want to delete the resource in the client
   first or wait for the server's response.
+  - `path` (Optional) Target API path where we want perform the save action. It
+      has preference over `url()`.
 
 #### `rpc(method: 'string', body?: {},  label?: 'fetching'): Promise`
 
@@ -515,6 +519,8 @@ Options:
 
   - `optimistic = true` Whether we want to create the resource in the client
   first or wait for the server's response.
+  - `path` (Optional) Target API path where we want perform the save action. It
+      has preference over `url()`.
 
 ```js
 const promise = tasksCollection.create({ name: 'Do laundry' })

--- a/__tests__/Collection.spec.ts
+++ b/__tests__/Collection.spec.ts
@@ -521,11 +521,14 @@ describe(Collection, () => {
   })
 
   describe('create(attributes, { optimistic = true })', () => {
+    let spy
     beforeEach(() => {
       collection.url = () => '/resources'
       collection.reset([])
-      jest.spyOn(apiClient(), 'post')
+      spy = jest.spyOn(apiClient(), 'post')
     })
+
+    afterEach(() => spy.mockRestore())
 
     it('builds a model and saves it', async () => {
       const attributes = { phone: '1234' }
@@ -599,6 +602,17 @@ describe(Collection, () => {
         } catch (errorObject) {
           expect(errorObject.error).toBe('Conflict')
         }
+      })
+    })
+
+    describe('with customized path', () => {
+      it('request to the given path', async () => {
+        const promise = collection.create({}, {
+          optimistic: false,
+          path: '/custom'
+        })
+
+        expect(spy.mock.calls[0][0]).toEqual('/custom')
       })
     })
   })

--- a/__tests__/Model.spec.ts
+++ b/__tests__/Model.spec.ts
@@ -1081,6 +1081,32 @@ describe(Model, () => {
         })
       })
     })
+
+    describe('with customized path', () => {
+      let spy
+
+      beforeEach(() => {
+        spy = jest.spyOn(apiClient(), 'post')
+      })
+
+      afterEach(() => spy.mockRestore())
+
+      it('request to the given path', async () => {
+        const promise = model.save({
+          addresses: {
+            address2: {
+              street: 'Street 2',
+              number: 2222
+            }
+          }
+        }, {
+          optimistic: false,
+          path: '/custom'
+        })
+
+        expect(spy.mock.calls[0][0]).toEqual('/custom')
+      })
+    })
   })
 
   describe('destroy(options)', () => {
@@ -1225,6 +1251,20 @@ describe(Model, () => {
               expect(errorObject.error).toBe('Conflict')
             }
           })
+        })
+      })
+
+      describe('with customized path', () => {
+        it('request to the given path', async () => {
+          model.collection = new MockCollection()
+          model.collection.models.push(model)
+
+          model.destroy({
+            optimistic: false,
+            path: '/custom'
+          })
+
+          expect(spy.mock.calls[0][0]).toEqual('/custom')
         })
       })
     })

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -338,10 +338,10 @@ export default abstract class Collection<T extends Model> extends Base {
   @action
   create (
     attributesOrModel: { [key: string]: any } | T,
-    { optimistic = true }: CreateOptions = {}
+    { optimistic = true, path }: CreateOptions = {}
   ): Request {
     const model = this.build(attributesOrModel)
-    const request = model.save({}, { optimistic })
+    const request = model.save({}, { optimistic, path })
     this.requests.push(request)
     const { promise } = request
 

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -239,6 +239,7 @@ export default class Model extends Base {
       optimistic = true,
       patch = true,
       keepChanges = false,
+      path,
       ...otherOptions
     }: SaveOptions = {}
   ): Request {
@@ -279,7 +280,7 @@ export default class Model extends Base {
     })
 
     const { promise, abort } = apiClient()[method](
-      this.url(),
+      path || this.url(),
       data,
       { onProgress, ...otherOptions }
     )
@@ -322,7 +323,7 @@ export default class Model extends Base {
    */
   @action
   destroy (
-    { data, optimistic = true, ...otherOptions }: DestroyOptions = {}
+    { data, optimistic = true, path, ...otherOptions }: DestroyOptions = {}
   ): Request {
     const collection = this.collection
 
@@ -336,7 +337,7 @@ export default class Model extends Base {
     }
 
     const { promise, abort } = apiClient().del(
-      this.url(),
+      path || this.url(),
       data,
       otherOptions
     )

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,11 +5,13 @@ export type RequestState = 'pending' | 'fulfilled' | 'rejected'
 export interface CreateOptions {
   optimistic?: boolean
   onProgress?: () => any
+  path?: string
 }
 
 export interface DestroyOptions {
   data?: {}
   optimistic?: boolean
+  path?: string
 }
 
 export interface SaveOptions {
@@ -17,6 +19,7 @@ export interface SaveOptions {
   patch?: boolean
   onProgress?: () => any
   keepChanges?: boolean
+  path?: string
 }
 
 export interface Response {


### PR DESCRIPTION
Right now, if you want to call to some API handler out of the REST
scope, `mobx-rest` only let's you to do it through the `rpc` method. At
the end, this call is performed as a `POST` request and a part of the
semantics of REST. One of this semantics, is that the entity your are
working with is not updated if the RPC call returns a payload.

To avoid this, this commit adds the capability to pass an optional
`endpoint` parameter to `create`, `save` and `destroy` to be able to
choose where is going to be performed the request, taking preference
over the `url()` model method.