### PR TITLE
Bugfix/optimize declaration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,36 @@
 # Changelog
 
-## `8.0.0``
+## `8.0.1`
+
+  - Fix the issue #101 caused by generated declaration files path changes
+
+## `8.0.0`
 
   - Migrated to mobx 6
 
-## `7.1.1``
+## `7.1.1`
 
   - Added `path` option to `Collection#create`, `Model#destroy` and `Model#save`
 
-## `7.1.0``
+## `7.1.0`
 
   - Added `Collection#last` method
 
-## `7.0.1``
+## `7.0.1`
 
   - One more performance improvement by optimizing `Collection#constructor` to just reset the collection
 
-## `7.0.0``
+## `7.0.0`
 
   - Breaking: Moved indexes as getters so they are available during the first `Collection#set` call in the constructor
   - Refactored `Collection#set` to batch all the additions so indexes are not recalculated for each addition.
   - Refactored `Model#constructor` to directly set the attributes instead of initialize with an empty map and replace it.
 
-## `6.0.1``
+## `6.0.1`
 
   - Fix peformance regression for `set` introduced in 4.0.0 with the addition of indexes: We were creating a model just to call the `primaryKey` method instead of just calling the prototype.
 
-## `6.0.0``
+## `6.0.0`
   - Remove mustFind and mustGet methods
 
 ## `5.0.7`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-rest",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "REST conventions for mobx.",
   "jest": {
     "roots": [

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "typescript": "4.0.5"
   },
   "main": "lib",
+  "types": "./lib/index.d.ts",
   "scripts": {
     "build": "yarn build:clean && rollup --config",
     "build:clean": "rimraf lib",
@@ -59,6 +60,7 @@
     "@types/lodash": "4.14.164",
     "deepmerge": "4.2.2",
     "lodash": "4.17.20",
-    "mobx": "^6.0.2"
+    "mobx": "^6.0.2",
+    "rollup-plugin-dts": "^3.0.1"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,29 +1,44 @@
-import typescript from 'rollup-plugin-typescript2'
-import resolve from 'rollup-plugin-node-resolve'
+import typescript from 'rollup-plugin-typescript2';
+import resolve from 'rollup-plugin-node-resolve';
+import dts from 'rollup-plugin-dts';
 
-export default {
-  input: './src/index.ts',
-  output: {
-    file: './lib/index.js',
-    format: 'cjs'
-  },
-  plugins: [
-    resolve(),
-    typescript()
-  ],
-  external: [
-    'lodash/compact',
-    'lodash/debounce',
-    'lodash/difference',
-    'lodash/includes',
-    'lodash/isEqual',
-    'lodash/isObject',
-    'lodash/isPlainObject',
-    'lodash/union',
-    'lodash/uniqueId',
-    'lodash/intersection',
-    'lodash/entries',
-    'deepmerge',
-    'mobx'
-  ]
-}
+export default [
+	{
+		input: './src/index.ts',
+		output: {
+			file: './lib/index.js',
+			format: 'cjs'
+		},
+		plugins: [
+			resolve(),
+			typescript({
+				tsconfigOverride: {
+					compilerOptions: {
+						declaration: false
+					}
+				}
+			})
+		],
+		external: [
+			'lodash/compact',
+			'lodash/debounce',
+			'lodash/difference',
+			'lodash/includes',
+			'lodash/isEqual',
+			'lodash/isObject',
+			'lodash/isPlainObject',
+			'lodash/union',
+			'lodash/uniqueId',
+			'lodash/intersection',
+			'lodash/entries',
+			'deepmerge',
+			'mobx'
+		]
+	},
+	{
+		// Generate bundled declaration file
+		input: './src/index.ts',
+		output: [ { file: './lib/index.d.ts', format: 'es' } ],
+		plugins: [ dts() ]
+	}
+];

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,5 @@ import Request from './Request'
 import ErrorObject from './ErrorObject'
 import apiClient from './apiClient'
 
+export * from "./types";
 export { Collection, Model, apiClient, Request, ErrorObject }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,13 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
+"@babel/code-frame@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
+  integrity sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
+  dependencies:
+    "@babel/highlight" "^7.12.13"
+
 "@babel/core@^7.1.0":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.4.tgz#84055750b05fcd50f9915a826b44fa347a825250"
@@ -185,6 +192,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
   integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
 
+"@babel/helper-validator-identifier@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz#d26cad8a47c65286b15df1547319a5d0bcf27288"
+  integrity sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==
+
 "@babel/helpers@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.12.1.tgz#8a8261c1d438ec18cb890434df4ec768734c1e79"
@@ -216,6 +228,15 @@
   integrity sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/highlight@^7.12.13":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.0.tgz#3197e375711ef6bf834e67d0daec88e4f46113cf"
+  integrity sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.0"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -3059,6 +3080,13 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+magic-string@^0.25.7:
+  version "0.25.7"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
+
 make-dir@^3.0.0, make-dir@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
@@ -3705,6 +3733,15 @@ rimraf@3.0.2, rimraf@^3.0.0:
   dependencies:
     glob "^7.1.3"
 
+rollup-plugin-dts@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-dts/-/rollup-plugin-dts-3.0.1.tgz#4419efb51d935cc0cff6f577f8aad97a980ee524"
+  integrity sha512-sdTsd0tEIV1b5Bio1k4Ei3N4/7jbwcVRdlYotGYdJOKR59JH7DzqKTSCbfaKPzuAcKTp7k317z2BzYJ3bkhDTw==
+  dependencies:
+    magic-string "^0.25.7"
+  optionalDependencies:
+    "@babel/code-frame" "^7.12.13"
+
 rollup-plugin-node-resolve@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.0.0.tgz#754abf4841ed4bab2241551cba0a11d04c57f290"
@@ -3973,6 +4010,11 @@ source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+sourcemap-codec@^1.4.4:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 spdx-correct@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
Fix issue #101

1. use the way mentioned by this article to bundle the type declaration file into one file https://medium.com/@martin_hotell/typescript-library-tips-rollup-your-types-995153cc81c7
2. export declarations from types.ts