### PR TITLE
Fix optimistic destroys for models in collections

### DIFF
--- a/__tests__/Collection.spec.ts
+++ b/__tests__/Collection.spec.ts
@@ -330,6 +330,14 @@ describe(Collection, () => {
     })
 
     describe('if the id is not registered', () => {
+      let consoleWarnMock
+
+      beforeEach(() => {
+        consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation()
+      })
+
+      afterEach(() => consoleWarnMock.mockRestore())
+
       it("doesn't throw", () => {
         collection.reset([{ id: 1 }])
 
@@ -363,6 +371,14 @@ describe(Collection, () => {
     })
 
     describe('if data is anything else', () => {
+      let consoleWarnMock
+
+      beforeEach(() => {
+        consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation()
+      })
+
+      afterEach(() => consoleWarnMock.mockRestore())
+
       it("don't throw", () => {
         expect(() => collection.remove('invalid')).not.toThrow()
       })

--- a/__tests__/Model.spec.ts
+++ b/__tests__/Model.spec.ts
@@ -1184,7 +1184,7 @@ describe(Model, () => {
 
       it('makes a DELETE request', () => {
         model.destroy()
-        expect(spy).toHaveBeenCalled()
+        expect(spy).toHaveBeenCalledWith('/resources/2', undefined, {})
       })
 
       describe('if optimistic and belongs to a collection', () => {
@@ -1192,6 +1192,8 @@ describe(Model, () => {
 
         beforeEach(() => {
           collection = new MockCollection()
+          collection.url = () => '/tasks'
+          model.urlRoot = () => null
           model.collection = collection
           collection.models.push(model)
         })
@@ -1200,6 +1202,7 @@ describe(Model, () => {
           expect(collection.length).toBe(1)
           model.destroy({ optimistic: true })
           expect(collection.length).toBe(0)
+          expect(spy).toHaveBeenCalledWith('/tasks/2', undefined, {})
         })
       })
 

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -325,16 +325,16 @@ export default class Model {
     }
     if (this.isNew) return
 
+    // It is important to compute the url before removing it if
+    // the url depends on the collection url.
+    const url = path || this.url()
+
     if (optimistic && collection) {
       collection.remove(this)
     }
 
     try {
-      const newData = await apiClient().del(
-        path || this.url(),
-        data,
-        otherOptions
-      )
+      const newData = await apiClient().del(url, data, otherOptions)
       if (!optimistic && collection) collection.remove(this)
 
       return newData


### PR DESCRIPTION
There is a bug when you try to destroy a model that is into a
collection. If you decide to do this optimistically, the request will
not be able to be performed because you can compute the url() because
the models is not present in the collection.