### PR TITLE
Collection get method can return undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## `11.0.0`
+
+  - Breaking: `Collection`'s `get` method return type is now typed to `T | undefined`.
+
+## `10.0.1`
+
+  - Fixed: optimistic destroys for models in collections.
+
 ## `10.0.0`
 
   - Simplify `Collection` and `Model` api, removing the `Request` wrapper.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-rest",
-  "version": "10.0.1",
+  "version": "11.0.0",
   "description": "REST conventions for mobx.",
   "jest": {
     "roots": [

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -153,7 +153,7 @@ export default abstract class Collection<T extends Model> {
   /**
    * Get a resource with the given id or uuid
    */
-  get(id: Id, { required = false }: GetOptions = {}): T {
+  get(id: Id, { required = false }: GetOptions = {}): T | undefined {
     const models = this.index.get(this.primaryKey).get(id)
     const model = models && models[0]
 


### PR DESCRIPTION
The `Collection`'s `get` method can return `undefined` so I fixed the type. I also bumped the version to a `major` since I consider this to be a breaking change.